### PR TITLE
Feat: Updating redirects

### DIFF
--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -1,70 +1,36 @@
-# HTTP server - redirect all to HTTPS
 server {
     listen 80;
     server_name jaquesburger.com www.jaquesburger.com;
-    
-    # Allow Let's Encrypt challenges
-    location /.well-known/acme-challenge/ {
-        allow all;
-        root /var/www/certbot;
-    }
-    
-    # Redirect all other traffic to HTTPS
-    location / {
-        return 301 https://$server_name$request_uri;
-    }
-}
 
-# HTTPS server
-server {
-    listen 443 ssl http2;
-    server_name jaquesburger.com www.jaquesburger.com;
-    
-    # SSL configuration
-    ssl_certificate /etc/letsencrypt/live/jaquesburger.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/jaquesburger.com/privkey.pem;
-    
-    # Modern SSL configuration
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
-    
-    # Proxy settings
     location / {
         proxy_pass http://portfolio-app:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
-        # Timeouts
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
     }
-    
-    # Serve static files directly (optional optimization)
+
     location /static {
         proxy_pass http://portfolio-app:5000/static;
         expires 30d;
         add_header Cache-Control "public, immutable";
     }
-    
-    # Health check endpoint
+
     location /health {
         access_log off;
         proxy_pass http://portfolio-app:5000/health;
     }
-    
-    # Deny access to hidden files
+
     location ~ /\. {
         deny all;
     }
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
 }


### PR DESCRIPTION
Updating redirects to remove old stale directs from certs as this is now handled by Cloudflare

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the site to serve traffic through a single HTTP reverse-proxy endpoint.
  * Preserved proxy routing, health checks, static content handling, hidden-file protection, and security headers.
  * Removed HTTPS-specific configuration, certificate handling, and automatic HTTP-to-HTTPS redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->